### PR TITLE
chore(version): bump version to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 An [Ethereum] light client in [CKB].
 
+The version 0.1.x is a single client cell solution, which is deprecated.
+And it's no longer maintained.
+
+Please use the latest version to instead of.
+
 [License]: https://img.shields.io/badge/License-MIT-blue.svg
 [GitHub Actions]: https://github.com/synapseweb3/eth-light-client-in-ckb/workflows/CI/badge.svg
 

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth_light_client_in_ckb-prover"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 authors = ["Boyu Yang <yangby@cryptape.com>"]
 edition = "2021"
 license = "MIT"

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth_light_client_in_ckb-verification"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 authors = ["Boyu Yang <yangby@cryptape.com>"]
 edition = "2021"
 license = "MIT"
@@ -24,7 +24,7 @@ eth2_types       = { git = "https://github.com/synapseweb3/lighthouse", rev = "3
 log              = { version = "0.4.17", optional = true }
 
 [dev-dependencies]
-eth_light_client_in_ckb-prover = { version = "0.1.0-alpha.0", path = "../prover" }
+eth_light_client_in_ckb-prover = { version = "0.1.0", path = "../prover" }
 serde_json = "1.0"
 walkdir = "2.3.2"
 ethers-core = "1.0.2"


### PR DESCRIPTION
Bump version to 0.1.0.

Then we will drop the design for only a single client cell,
and move on the design for multi client cells.
