### PR TITLE
feat: verifies `new MMR = old MMR + all incremental headers`

### DIFF
--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/synapseweb3/eth-light-client-in-ckb"
 
 [dependencies]
 molecule         = { version = "=0.7.5", default-features = false }
-ckb-mmr          = { version = "0.5.2", default-features = false, package = "ckb-merkle-mountain-range" }
+ckb-mmr          = { version = "0.6.0", default-features = false, package = "ckb-merkle-mountain-range" }
 rlp              = { version = "0.5.2", default-features = false }
 ethereum-types   = { version = "0.14.1", default-features = false  }
 tiny-keccak      = { version = "2.0.2", features = ["keccak"] }


### PR DESCRIPTION
### Issue

The old code only checks:
- Whether the new MMR root contains all-new appended headers.

But it doesn't check:
- Whether the new MMR root is a successor of the old MMR root.
- If there exists any headers not list in the new-appended headers, but they are contained in the new MMR root.

As a permissionless solution, it has to avoid those potential attracts.

### Solution

Just upgrade the dependency and introduce a new API.

More details could be found in:
- nervosnetwork/merkle-mountain-range#33
- nervosnetwork/merkle-mountain-range#35

### Tips for Review

- No break changes.
- The `positions` is removed, since the new API considers that all new appended headers are continuous with the previous headers, so it calculates the positions of headers inside itself.
- Currently, we have unit tests for this change.