### PR TITLE
chore(version): bump version to 0.2.3

### DIFF
--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth_light_client_in_ckb-prover"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Boyu Yang <yangby@cryptape.com>"]
 edition = "2021"
 license = "MIT"
@@ -9,7 +9,7 @@ homepage = "https://github.com/synapseweb3/eth-light-client-in-ckb"
 repository = "https://github.com/synapseweb3/eth-light-client-in-ckb"
 
 [dependencies]
-eth_light_client_in_ckb-verification = { version = "0.2.1", path = "../verification" }
+eth_light_client_in_ckb-verification = { version = "0.2.2", path = "../verification" }
 ethers-core = "2.0.2"
 cita_trie = "4.0.0"
 hasher = "0.1.4"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth_light_client_in_ckb-prover"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Boyu Yang <yangby@cryptape.com>"]
 edition = "2021"
 license = "MIT"
@@ -9,7 +9,7 @@ homepage = "https://github.com/synapseweb3/eth-light-client-in-ckb"
 repository = "https://github.com/synapseweb3/eth-light-client-in-ckb"
 
 [dependencies]
-eth_light_client_in_ckb-verification = { version = "0.2.2", path = "../verification" }
+eth_light_client_in_ckb-verification = { version = "0.2.3", path = "../verification" }
 ethers-core = "2.0.2"
 cita_trie = "4.0.0"
 hasher = "0.1.4"

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth_light_client_in_ckb-verification"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Boyu Yang <yangby@cryptape.com>"]
 edition = "2021"
 license = "MIT"
@@ -24,7 +24,7 @@ eth2_types       = { git = "https://github.com/synapseweb3/lighthouse", rev = "2
 log              = { version = "0.4.17", optional = true }
 
 [dev-dependencies]
-eth_light_client_in_ckb-prover = { version = "0.2.1", path = "../prover" }
+eth_light_client_in_ckb-prover = { version = "0.2.2", path = "../prover" }
 serde_json = "1.0"
 walkdir = "2.3.3"
 ethers-core = "2.0.2"

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth_light_client_in_ckb-verification"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Boyu Yang <yangby@cryptape.com>"]
 edition = "2021"
 license = "MIT"
@@ -24,7 +24,7 @@ eth2_types       = { git = "https://github.com/synapseweb3/lighthouse", rev = "2
 log              = { version = "0.4.17", optional = true }
 
 [dev-dependencies]
-eth_light_client_in_ckb-prover = { version = "0.2.2", path = "../prover" }
+eth_light_client_in_ckb-prover = { version = "0.2.3", path = "../prover" }
 serde_json = "1.0"
 walkdir = "2.3.3"
 ethers-core = "2.0.2"


### PR DESCRIPTION
v0.2.2 was released with some mistake, so bump version to 0.2.3 directly